### PR TITLE
bugfix/MAR-779 to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unique-marketplace-api",
-  "version": "1.7.72",
+  "version": "1.7.73",
   "description": "Backend project for unique marketplace",
   "author": "Unique Network",
   "private": true,

--- a/src/entity/offer-filters.ts
+++ b/src/entity/offer-filters.ts
@@ -109,9 +109,6 @@ export class OfferFilters {
   @ViewColumn({ name: 'auction_stop_at' })
   auctionStopAt: Date;
 
-  @ViewColumn({ name: 'auction_contract_ask_id' })
-  auctionContractAskId: string;
-
   @ViewColumn({ name: 'auction_bidder_address' })
   auctionBidderAddress: string;
 

--- a/src/offers/dto/offer-dto.ts
+++ b/src/offers/dto/offer-dto.ts
@@ -57,6 +57,15 @@ export class OfferEntityDto {
   @ApiProperty({ description: 'Contract ask from', example: '5CfC8HRcV5Rc4jHFHmZsSjADCMYc7zoWbvxdoNG9qwEP7aUB' })
   @Expose()
   seller: string;
+
+  @ApiProperty({ description: 'Type offer' })
+  @Expose()
+  type: string;
+
+  @ApiProperty({ description: 'Status offer' })
+  @Expose()
+  status: string;
+
   @ApiProperty({ description: 'Date blockchain block created' })
   @Expose()
   creationDate: Date;
@@ -72,6 +81,7 @@ export class OfferEntityDto {
   tokenDescription: TokenDescriptionDto;
 
   static fromOffersEntity(offersData: OffersEntity): OfferEntityDto {
+    console.dir(offersData, { depth: 3 });
     const plain: Record<string, any> = {
       ...offersData,
       collectionId: +offersData.collection_id,
@@ -80,6 +90,7 @@ export class OfferEntityDto {
       quoteId: +offersData.currency,
       seller: offersData.address_from,
       creationDate: offersData.created_at,
+      status: offersData.status,
       types: offersData.type,
     };
 

--- a/src/offers/offers.service.ts
+++ b/src/offers/offers.service.ts
@@ -190,6 +190,8 @@ export class OffersService {
         const obj = {
           collection_id: +item.collection_id,
           token_id: +item.token_id,
+          status: item.offer_status,
+          type: item.offer_type,
           price: item.offer_price,
           currency: +item.offer_currency,
           address_from: item.offer_address_from,


### PR DESCRIPTION
fix: Added status and type for offers of filter
- Removed field `auction_contract_ask_id` from entity `offer_filter`;
- Returned logic of work for attributes;
- Added fields `status` and `type` to response for identification;
- Updated DTO for `offer-dto`;

Issue: MAR-783